### PR TITLE
Add configurable filename separator to `log_image`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/ImageReducer.test.ts
@@ -106,6 +106,51 @@ describe('ImageReducer', () => {
     });
   });
 
+  it('should add images to the state for file list of different valid delimiters', () => {
+    const initialState = {};
+    const action: AsyncFulfilledAction<ListImagesAction> = {
+      type: 'LIST_IMAGES_API_FULFILLED',
+      payload: {
+        files: [
+          {
+            path: 'images/image1%step%0%timestamp%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            path: 'images/image2+step+1+timestamp+1+UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+        ],
+        root_uri: '',
+      },
+      meta: {
+        id: '123',
+        runUuid: '123',
+      },
+    };
+    const newState = imagesByRunUuid(initialState, action);
+    expect(newState).toEqual({
+      '123': {
+        image1: {
+          'image1%step%0%timestamp%1%UUID': {
+            filepath: 'images/image1%step%0%timestamp%1%UUID.png',
+            step: 0,
+            timestamp: 1,
+          },
+        },
+        image2: {
+          'image2+step+1+timestamp+1+UUID': {
+            filepath: 'images/image2+step+1+timestamp+1+UUID.png',
+            step: 1,
+            timestamp: 1,
+          },
+        },
+      },
+    });
+  });
+
   it('should handle error and prevent state update on malformed inputs', () => {
     const initialState = {};
     const action: AsyncFulfilledAction<ListImagesAction> = {
@@ -113,7 +158,26 @@ describe('ImageReducer', () => {
       payload: {
         files: [
           {
+            // missing timestamp
             path: 'images/image1%step%0%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            // missing step
+            path: 'images/image1%timestamp%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            // mixed delimiters + first
+            path: 'images/image1+step%0%timestamp%1%UUID.png',
+            is_dir: false,
+            file_size: 123,
+          },
+          {
+            // mixed delimiters % first
+            path: 'images/image1%step+0%timestamp%1%UUID.png',
             is_dir: false,
             file_size: 123,
           },

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -151,6 +151,8 @@ _STAGES_DEPRECATION_WARNING = (
     "latest/model-registry.html#migrating-from-stages"
 )
 
+_ALLOWED_FILENAME_SEPARATORS = {"%", "+"}
+
 
 def _model_not_found(name: str) -> MlflowException:
     return MlflowException(
@@ -2950,7 +2952,7 @@ class MlflowClient:
             # See https://github.com/mlflow/mlflow/issues/14136 for more details.
             # Construct a filename uuid that does not start with hex digits
             filename_uuid = f"{random.choice(string.ascii_lowercase[6:])}{filename_uuid[1:]}"
-            if filename_sep not in ["%", "+"]:
+            if filename_sep not in _ALLOWED_FILENAME_SEPARATORS:
                 logging.warning(
                     f"Invalid image log file separator '{filename_sep}' specified. \
                     Defaulting to '%'."

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2831,8 +2831,8 @@ class MlflowClient:
                 `MLFLOW_ENABLE_ASYNC_LOGGING`, which defaults to False if not set.
             filename_sep: The separator used in the image filename. Defaults to "%". This is used to
                 by the frontend to derive step and timestamp information from the filename.
-                For example: `image%step%0%timestamp%1697051234567%uuid.png` or
-                `image+step+0+timestamp+1697051234567+uuid.png`
+                If `key` contains the separator, it will be replaced with a dash (-) to avoid
+                ambiguity.
 
 
         .. code-block:: python
@@ -2944,6 +2944,7 @@ class MlflowClient:
 
             # Sanitize key to use in filename (replace / with # to avoid subdirectories)
             sanitized_key = re.sub(r"/", "#", key)
+            sanitized_key = re.sub(r"[" + filename_sep + r"]+", "-", sanitized_key)
             filename_uuid = str(uuid.uuid4())
             # TODO: reconsider the separator used here since % has special meaning in URL encoding.
             # See https://github.com/mlflow/mlflow/issues/14136 for more details.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1671,8 +1671,8 @@ def log_image(
         synchronous: *Experimental* If True, blocks until the image is logged successfully.
         filename_sep: The separator used in the image filename. Defaults to "%". This is used to
             by the frontend to derive step and timestamp information from the filename.
-            For example: `image%step%0%timestamp%1697051234567%uuid.png` or
-            `image+step+0+timestamp+1697051234567+uuid.png`
+            If `key` contains the separator, it will be replaced with a dash (-) to avoid
+            ambiguity.
 
     .. code-block:: python
         :caption: Time-stepped image logging numpy example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -84,7 +84,9 @@ if not IS_TRACING_SDK_ONLY:
     from mlflow.tracking import _get_artifact_repo, _get_store, artifact_utils
     from mlflow.tracking.client import MlflowClient
     from mlflow.tracking.context import registry as context_registry
-    from mlflow.tracking.default_experiment import registry as default_experiment_registry
+    from mlflow.tracking.default_experiment import (
+        registry as default_experiment_registry,
+    )
 
 
 if TYPE_CHECKING:
@@ -232,7 +234,9 @@ def _set_experiment_primary_metric(
     client = MlflowClient()
     client.set_experiment_tag(experiment_id, MLFLOW_EXPERIMENT_PRIMARY_METRIC_NAME, primary_metric)
     client.set_experiment_tag(
-        experiment_id, MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER, str(greater_is_better)
+        experiment_id,
+        MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER,
+        str(greater_is_better),
     )
 
 
@@ -413,7 +417,10 @@ def start_run(
         # Use previous `end_time` because a value is required for `update_run_info`.
         end_time = active_run_obj.info.end_time
         _get_store().update_run_info(
-            existing_run_id, run_status=RunStatus.RUNNING, end_time=end_time, run_name=None
+            existing_run_id,
+            run_status=RunStatus.RUNNING,
+            end_time=end_time,
+            run_name=None,
         )
         tags = tags or {}
         if description:
@@ -490,7 +497,9 @@ def start_run(
                 "`mlflow.start_run()` or calling `mlflow.disable_system_metrics_logging`."
             )
         try:
-            from mlflow.system_metrics.system_metrics_monitor import SystemMetricsMonitor
+            from mlflow.system_metrics.system_metrics_monitor import (
+                SystemMetricsMonitor,
+            )
 
             system_monitor = SystemMetricsMonitor(
                 active_run_obj.info.run_id,
@@ -1598,6 +1607,7 @@ def log_image(
     step: int | None = None,
     timestamp: int | None = None,
     synchronous: bool | None = False,
+    filename_sep: Literal["%", "+"] = "%",
 ) -> None:
     """
     Logs an image in MLflow, supporting two use cases:
@@ -1659,6 +1669,10 @@ def log_image(
             Defaults to 0.
         timestamp: Time when this image was saved. Defaults to the current system time.
         synchronous: *Experimental* If True, blocks until the image is logged successfully.
+        filename_sep: The separator used in the image filename. Defaults to "%". This is used to
+            by the frontend to derive step and timestamp information from the filename.
+            For example: `image%step%0%timestamp%1697051234567%uuid.png` or
+            `image+step+0+timestamp+1697051234567+uuid.png`
 
     .. code-block:: python
         :caption: Time-stepped image logging numpy example
@@ -1718,7 +1732,9 @@ def log_image(
             mlflow.log_image(image, "image.png")
     """
     run_id = _get_or_start_run().info.run_id
-    MlflowClient().log_image(run_id, image, artifact_file, key, step, timestamp, synchronous)
+    MlflowClient().log_image(
+        run_id, image, artifact_file, key, step, timestamp, synchronous, filename_sep
+    )
 
 
 def log_table(


### PR DESCRIPTION

### Related Issues/PRs

#### Related

- Issue - [Logged Images Not Displaying in MLFlow UI](https://github.com/mlflow/mlflow/issues/14136)
- PR - [Filename encoding issue in `log_image`](https://github.com/mlflow/mlflow/pull/14281)

### What changes are proposed in this pull request?

Adds a `filename_sep` argument to `log_image` that allows user to set the filename separator as either `%` or `+` to avoid
conflicts with `%` URL encodings where applicable. Defaults to `%`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduces a new `filename_sep` parameter to `log_image` enabling control over the separator used in generated artifact filenames.
Currently supported separators are `%` or `+`. Defaults to `%`.
ome downstream systems or tooling treat % in file paths ambiguously due to URL encoding semantics (e.g. `%20` for spaces). 
Allowing `+` helps avoid confusion or the need for additional escaping when serving or linking image artifacts via HTTP.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

### Commit Summary
- **Add `filename_sep` argument to `log_image` - only supports  `%` and `+` - defaults to `%` to keep current behavior**
- **Add tests to `ImageReducer` to ensure compat for images with different delimiters in payloads**
- **Also sanitize image key for filename sep - replace with `-`**
- **Add constant `_ALLOWED_FILENAME_SEPARATORS` for constraining `log_image` `filename_sep` argument**
